### PR TITLE
feat: use index file to export related containers

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,11 +21,13 @@ import CreateRequest from './components/Request/CreateRequest/CreateRequest';
 import RequestDetail from './containers/Requests/RequestDetail/RequestDetail';
 import RequestList from './containers/Requests/RequestList/RequestList';
 
-import VolunteerList from './containers/Volunteer/VolunteerList/VolunteerList';
-import VolunteerDetail from './containers/Volunteer/VolunteerDetail/VolunteerDetail';
-import MyVolunteerList from './containers/Volunteer/MyVolunteer/MyVolunteerList';
-import MyVolunteerDetail from './containers/Volunteer/MyVolunteer/MyVolunteerDetail';
-import SignUp from './containers/Volunteer/SignUp/SignUp';
+import {
+  VolunteerList,
+  VolunteerDetail,
+  MyVolunteerList,
+  MyVolunteerDetail,
+  SignUp,
+} from './containers/Volunteer';
 
 import ProtectedRoute from './components/ProtectedRoute/ProtectedRoute';
 import { withRouter } from 'react-router';

--- a/src/containers/Volunteer/index.js
+++ b/src/containers/Volunteer/index.js
@@ -1,0 +1,13 @@
+import VolunteerList from './VolunteerList/VolunteerList';
+import VolunteerDetail from './VolunteerDetail/VolunteerDetail';
+import MyVolunteerList from './MyVolunteer/MyVolunteerList';
+import MyVolunteerDetail from './MyVolunteer/MyVolunteerDetail';
+import SignUp from './SignUp/SignUp';
+
+export {
+  VolunteerList,
+  VolunteerDetail,
+  MyVolunteerList,
+  MyVolunteerDetail,
+  SignUp,
+};


### PR DESCRIPTION
part of #15 and #14 

@torshimizu, @pianote and I had a chat about file organization, and we had tentatively decided on keeping things nested 1 directory deep, so changing this: 

```
containers/Volunteer/VolunteerList/
containers/Volunteer/VolunteerDetail/
containers/Volunteer/MyVolunteer/
```

to this:

```
containers/VolunteerList/
containers/VolunteerDetail/
containers/MyVolunteer/
```

this PR does *not* do that, because that's going to be a very big effort. I was thinking if we didn't want to undertake that in the very near future, we could bundle similar components into an index file and export them all from one place. this at least makes understanding similar concerns a little bit easier, but it might make adding new ones more complicated.