### PR TITLE
make FAQ page responsive

### DIFF
--- a/src/containers/FAQ/Faq.tsx
+++ b/src/containers/FAQ/Faq.tsx
@@ -51,8 +51,8 @@ interface Props { }
 const Faq: FC<Props> = () => {
   return (
     <div className="page-container">
-      <header>
-        <h3>Frequently Asked Questions</h3>
+      <header id="topOfPage">
+        <h2>Frequently Asked Questions</h2>
       </header>
       <section className="faq">
         <ul className="faq__categories">

--- a/src/containers/FAQ/faq.css
+++ b/src/containers/FAQ/faq.css
@@ -2,13 +2,27 @@
   margin: 20px 40px;
 }
 
+@media screen and (max-width: 800px) {
+  .page-container {
+    width: 100%;
+    margin: 0;
+    padding: 0;
+  }
+}
+
 ul {
   list-style: none;
   padding: 0;
 }
 
 header {
-  margin-bottom: 20px;
+  margin: 20px 0;
+}
+
+@media screen and (max-width: 800px) {
+  header {
+    text-align: center;
+  }
 }
 
 .faq {
@@ -19,6 +33,31 @@ header {
 
 .faq a {
   text-decoration: none
+}
+
+@media screen and (max-width: 800px) {
+  .faq {
+    display: flex;
+    flex-flow: column wrap;
+    width: 100%;
+    padding: 0;
+  }
+}
+
+@media screen and (max-width: 800px) {
+  .faq__categories, .faq__items, .faq__category, .faq__group {
+    width: 100%;
+    /* The width is 100%, when the viewport is 800px or smaller */
+  }
+}
+
+@media screen and (max-width: 800px) {
+  .faq__categories {
+    width: 100%;
+    position: relative;
+    padding: 0;
+    margin: 0;
+  }
 }
 
 .faq__categories {
@@ -61,10 +100,19 @@ header {
   z-index: 1;
   height: 100%;
   width: 80%;
-  margin: 0 40px;
+  margin: 0 5px;
   background: hsl(0, 0%, 100%);
   padding: 0 1.25em 1.25em;
   overflow: auto;
+}
+
+@media screen and (max-width: 800px) {
+  .faq__items {
+    width: 100%;
+    position: relative;
+    padding: 0 5%;
+    margin: 0;
+  }
 }
 
 .faq__group {


### PR DESCRIPTION
Optimizations for mobile:
- layout changes to a column at < 800px screen size,
- centers header text,
- makes content full width